### PR TITLE
Fix email giving error 00085 Email is not valid, change fallback email

### DIFF
--- a/app/code/local/Shipfunk/Shipfunk/Model/Carrier.php
+++ b/app/code/local/Shipfunk/Shipfunk/Model/Carrier.php
@@ -78,7 +78,7 @@ class Shipfunk_Shipfunk_Model_Carrier extends Mage_Shipping_Model_Carrier_Abstra
                     "city" => (!empty($request->getDestCity()))?urlencode($request->getDestCity()):"Temp city",
                     "country" => (!empty($request->getDestCountryId()))?$request->getDestCountryId():"FI",
                     "phone" => (!empty($request->getTelephone()))?urlencode($request->getTelephone()):"1234567890",
-                    "email" => (!empty($customer->getEmail()) && !filter_var($customer->getEmail(), FILTER_VALIDATE_EMAIL) === false)?$customer->getEmail():"shipfunk@shipfunk.fi"
+                    "email" => (!empty($customer->getEmail()) && !filter_var($customer->getEmail(), FILTER_VALIDATE_EMAIL) === false)?$customer->getEmail():null
                 )
             )
         );

--- a/app/code/local/Shipfunk/Shipfunk/Model/Carrier.php
+++ b/app/code/local/Shipfunk/Shipfunk/Model/Carrier.php
@@ -78,8 +78,8 @@ class Shipfunk_Shipfunk_Model_Carrier extends Mage_Shipping_Model_Carrier_Abstra
                     "city" => (!empty($request->getDestCity()))?urlencode($request->getDestCity()):"Temp city",
                     "country" => (!empty($request->getDestCountryId()))?$request->getDestCountryId():"FI",
                     "phone" => (!empty($request->getTelephone()))?urlencode($request->getTelephone()):"1234567890",
-                    "email" => (!empty($customer->getEmail()) && !filter_var($customer->getEmail(), FILTER_VALIDATE_EMAIL) === false)?urlencode($customer->getEmail()):"shipfunk@shipfunk.fi"
-                ) 
+                    "email" => (!empty($customer->getEmail()) && !filter_var($customer->getEmail(), FILTER_VALIDATE_EMAIL) === false)?$customer->getEmail():"shipfunk@shipfunk.fi"
+                )
             )
         );
         $attributeCode=array(
@@ -332,11 +332,11 @@ class Shipfunk_Shipfunk_Model_Carrier extends Mage_Shipping_Model_Carrier_Abstra
                     "city" => (!empty($address->getDestCity()))?urlencode($address->getDestCity()):"Temp city",
                     "country" => (!empty($address->getDestCountryId()))?$address->getDestCountryId():"FI",
                     "phone" => (!empty($address->getTelephone()))?urlencode($address->getTelephone()):"1234567890",
-                    "email" => (!empty($customer->getEmail()) && !filter_var($customer->getEmail(), FILTER_VALIDATE_EMAIL) === false)?urlencode($customer->getEmail()):"temp@10sport.fi"
+                    "email" => (!empty($customer->getEmail()) && !filter_var($customer->getEmail(), FILTER_VALIDATE_EMAIL) === false)?$customer->getEmail():"shipfunk@shipfunk.fi"
                 )
             )
         );
-    
+
         $items = $cart->getAllItems();
         $data['query']['order']['language']=$lang;
         $data['query']['order']['monetary']=array(

--- a/app/code/local/Shipfunk/Shipfunk/Model/Carrier.php
+++ b/app/code/local/Shipfunk/Shipfunk/Model/Carrier.php
@@ -332,7 +332,7 @@ class Shipfunk_Shipfunk_Model_Carrier extends Mage_Shipping_Model_Carrier_Abstra
                     "city" => (!empty($address->getDestCity()))?urlencode($address->getDestCity()):"Temp city",
                     "country" => (!empty($address->getDestCountryId()))?$address->getDestCountryId():"FI",
                     "phone" => (!empty($address->getTelephone()))?urlencode($address->getTelephone()):"1234567890",
-                    "email" => (!empty($customer->getEmail()) && !filter_var($customer->getEmail(), FILTER_VALIDATE_EMAIL) === false)?$customer->getEmail():"shipfunk@shipfunk.fi"
+                    "email" => (!empty($customer->getEmail()) && !filter_var($customer->getEmail(), FILTER_VALIDATE_EMAIL) === false)?$customer->getEmail():null
                 )
             )
         );


### PR DESCRIPTION
Fix Shipfunk API giving error as email for logged in user is urlencoded in format like eero%40hakio.fi
Returning error:
[Code] => 00085
[Message] => Email is not valid.

Note: Issue occurred only on logged in users.
Occurred and Tested on: Magento 1.9.2.4, 1.9.4.1